### PR TITLE
feat: subquestion answers clear w/ answer declined

### DIFF
--- a/lib/_internal/utils/answer_response_util.dart
+++ b/lib/_internal/utils/answer_response_util.dart
@@ -13,6 +13,22 @@ class AnswerResponseUtil {
           orElse: () => newAnswerResponseFromAnswerAndValue(
               answer: answer, newValue: ''));
 
+  String getAnswerCodeFromAnswerResponse(
+      AnswerResponse answerResponse, Rx<UserResponse> userResponse) {
+    String answerCode;
+
+    if (answerResponse is AnswerCode) {
+      answerCode = answerResponse.value;
+    } else if (answerResponse is AnswerOther) {
+      answerCode = answerResponse.code;
+    } else if (answerResponse is AnswerBoolean) {
+      answerCode = answerResponse.code;
+    } else {
+      answerCode = userResponse.value.questionLinkId;
+    }
+    return answerCode;
+  }
+
   void setAnswerResponseValue(
           AnswerResponse answerResponse, dynamic newValue) =>
       answerResponse.value = newValue;

--- a/lib/controllers/commands/debounce_and_save_response_command.dart
+++ b/lib/controllers/commands/debounce_and_save_response_command.dart
@@ -14,7 +14,7 @@ class DebounceAndSaveResponseCommand extends AbstractCommand {
       final _question =
           questionnaireController.getQuestionFromUserResponse(userResponse);
 
-      void _clearResponse() => UserResponseUtil().clearUserResponse(
+      void _clearResponse() => UserResponseUtil().clearUserResponseByAnswer(
           answer: answer,
           userResponse: userResponse,
           qFormat: _question.format,

--- a/lib/controllers/commands/toggle_decline_to_respond_command.dart
+++ b/lib/controllers/commands/toggle_decline_to_respond_command.dart
@@ -23,7 +23,7 @@ class ToggleDeclineToRespondCommand extends AbstractCommand {
     // when toggled on...
     if (newValue) {
       // remove other/prior responses for this question
-      responsesController.clearAllUserResponses(userResponse);
+      responsesController.clearAllUserResponses(userResponse, true);
     }
 
     validationController.validateIfQuestionAndGroupAreCompleted(userResponse);

--- a/lib/controllers/fhir_questionnaire/validation_controller.dart
+++ b/lib/controllers/fhir_questionnaire/validation_controller.dart
@@ -131,29 +131,40 @@ class ValidationController extends GetxController {
 
     // check for subquestion
     if (userResponse.value.questionLinkId != groupAndQuestionId &&
-        // nested 'choose not to respond' items handled separately
+        // nested 'choose not to respond' items are handled separately
         LinkIdUtil().getLastId(userResponse.value.questionLinkId) !=
             'LA30122-8') {
       //subquestion
-      // todo: handle subquestion data
-      _isQuestionAnswered = _validateSubQuestion();
+      _isQuestionAnswered = _validateSubQuestion(groupAndQuestionId);
     } else {
       // validate based on question type
       _isQuestionAnswered =
           _validateAnswerResponseListHasData(userResponse.value.answers);
-      // note that a declined question takes priority counts as answered
-      _isQuestionDeclined =
-          questionValidatorsMap[groupAndQuestionId].isQuestionDeclined.value;
-
-      qValidators.isQuestionAnswered.value = _isQuestionAnswered;
     }
+    // note that a declined question takes priority counts as answered
+    _isQuestionDeclined =
+        questionValidatorsMap[groupAndQuestionId].isQuestionDeclined.value;
+
+    qValidators.isQuestionAnswered.value = _isQuestionAnswered;
 
     _validateIfGroupIsCompleted(userResponse.value.questionLinkId);
 
     return _isQuestionAnswered || _isQuestionDeclined;
   }
 
-  bool _validateSubQuestion() => false;
+  bool _validateSubQuestion(String groupAndQuestionId) {
+    bool _isSubQuestionAnswered = false;
+
+    _responsesController.userResponsesMap.forEach((qLinkId, usrResp) {
+      if (qLinkId.contains(groupAndQuestionId)) {
+        if (_validateAnswerResponseListHasData(usrResp.value.answers)) {
+          _isSubQuestionAnswered = true;
+        }
+      }
+    });
+
+    return _isSubQuestionAnswered;
+  }
 
   bool _validateIfGroupIsCompleted(String questionCode) {
     final String groupCode = LinkIdUtil().getGroupId(questionCode);

--- a/lib/ui/views/survey/answer/enable_when_option.dart
+++ b/lib/ui/views/survey/answer/enable_when_option.dart
@@ -41,7 +41,6 @@ class EnableWhenOption extends StatelessWidget {
             enabledQuestion.answers.firstWhere((e) => e.code == answer.code);
         final Rx<UserResponse> enabledUserResponse =
             userResponsesController.findActiveResponse(enabledQuestion.linkId);
-        print('');
 
         return Column(
           mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
added error handling, for when Get.find is unable to find a controller. A good example of this is question 14, which may have an optional value shown (thus, `TextEditingController`) or it may not.  Try / catch will allow the relevant validation methods to continue running even if no controller exists.

finally, added validation to all subquestions. Toggling an answer as declined should also clear the entire question's data