### PR TITLE
Fixed to upload to a different Sarah

### DIFF
--- a/lib/models/fhir_questionnaire/questionnaire_model.dart
+++ b/lib/models/fhir_questionnaire/questionnaire_model.dart
@@ -11,6 +11,7 @@ import 'survey/export.dart';
 import 'survey/survey_item/survey_item.dart';
 
 class QuestionnaireModel {
+  static const patientId = 'SarahThompson';
   final FhirQuestionnaire _data = FhirQuestionnaire();
   FhirQuestionnaire get data => _data;
   final Map<SDOH_FACTOR, Condition> _conditions = {};
@@ -68,7 +69,7 @@ class QuestionnaireModel {
     _data.userResponses.addAll(responses);
     _data.response = QuestionnaireResponse(
       // todo: remove hardcoded (example) patient reference
-      subject: Reference(reference: 'Patient/4890'),
+      subject: Reference(reference: 'Patient/$patientId'),
       resourceType: 'QuestionnaireResponse',
       meta: _data.questionnaire.meta,
       status: QuestionnaireResponseStatus.completed,
@@ -266,11 +267,12 @@ class QuestionnaireModel {
 
   void recordCondAndObs(SDOH_FACTOR factor) {
     if (!_conditions.keys.contains(factor)) {
-      _conditions[factor] = ConditionUtil().fhirCondition(factor, Id('4890'));
+      _conditions[factor] =
+          ConditionUtil().fhirCondition(factor, Id('$patientId'));
     }
     if (!_conditions.keys.contains(factor)) {
       _observations[factor] =
-          ObservationUtil().fhirObservation(factor, Id('4890'));
+          ObservationUtil().fhirObservation(factor, Id('$patientId'));
     }
   }
 }

--- a/lib/services/fhir_servers/hapi_service.dart
+++ b/lib/services/fhir_servers/hapi_service.dart
@@ -9,7 +9,8 @@ class HapiService {
       base: Uri.parse('http://hapi.fhir.org/baseR4'),
     );
 
-    bundle = Bundle.fromYaml(bundle.toYaml().replaceAll('4890', '1274896'));
+    bundle =
+        Bundle.fromYaml(bundle.toYaml().replaceAll('SarahThompson', '1274896'));
     final response = await request.request(bundle);
 
     return response.fold(


### PR DESCRIPTION
Moved the patientId to top of questionnaire_model class to make it easier to change. (still have to manually change it for HAPI, because it has to be a patient that's already been created on their server).